### PR TITLE
Compile GResource at runtime when in debug mode.

### DIFF
--- a/src/bindings/gio/resource.cr
+++ b/src/bindings/gio/resource.cr
@@ -1,21 +1,29 @@
 module Gio
   # Load the XML *resource_file* and register it, returning the `Gio::Resource`.
   #
-  # This macro runs `glib-compile-resources` at compile time, so the XML is only needed at compile time.
+  # When compiling in release mode this macro runs `glib-compile-resources` at compile time, so the XML is only needed at
+  # compile time. However when running in debug mode this macro runs `glib-compile-resources` at run time, so you don't
+  # need to recompile your program to e.g. see the changes in a UI file inside a GResource.
   #
   # By default the *resource_file* is read from the same directory where the compiler was invoked, to read it from
   # a different directory use the *sourcedir* parameter.
   #
   # See `examples/resource.cr` for more info.
   macro register_resource(resource_file, source_dir = ".")
-    {%
-      `glib-compile-resources --sourcedir #{source_dir} --target crystal-gio-resource.gresource #{resource_file}`
-      data = read_file("crystal-gio-resource.gresource")
-      # FIXME: This wont work on windows
-      `rm crystal-gio-resource.gresource`
-    %}
     begin
+      {% if flag?(:debug) %}
+        `glib-compile-resources --sourcedir #{{{source_dir}}} --target crystal-gio-resource.gresource #{{{resource_file}}}`
+        %resource_data = File.read("crystal-gio-resource.gresource")
+        File.delete("crystal-gio-resource.gresource")
+      {% else %}
+      {%
+        `glib-compile-resources --sourcedir #{source_dir} --target crystal-gio-resource.gresource #{resource_file}`
+        data = read_file("crystal-gio-resource.gresource")
+        # FIXME: This wont work on windows
+        `rm crystal-gio-resource.gresource`
+      %}
       %resource_data = {{ data }}
+      {% end %}
       %gbytes = LibGLib.g_bytes_new_static(%resource_data, %resource_data.bytesize)
       %error = Pointer(LibGLib::Error).null
       %resource_ptr = LibGio.g_resource_new_from_data(%gbytes, pointerof(%error))


### PR DESCRIPTION
This is useful when using UI files on Resource files.